### PR TITLE
Improved workshop download reliability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ EXPOSE 2306/udp
 
 WORKDIR /arma3
 
-VOLUME /arma3
+VOLUME /steamcmd
 
 STOPSIGNAL SIGINT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         python3 \
         rename \
         wget \
+        git \
     && \
     apt-get remove --purge -y \
     && \
@@ -48,6 +49,9 @@ ENV STEAM_USERNAME=
 ENV STEAM_VALIDATE=1
 ENV WORKSHOP_MODS=
 
+ENV CHECK_MODS=1
+ENV DOWNLOAD_ATTEMPTS=2
+
 EXPOSE 2302/udp
 EXPOSE 2303/udp
 EXPOSE 2304/udp
@@ -56,7 +60,7 @@ EXPOSE 2306/udp
 
 WORKDIR /arma3
 
-VOLUME /steamcmd
+VOLUME /arma3
 
 STOPSIGNAL SIGINT
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Allows for caching steam, Arma3, and workshop mods install OR downloading any (o
 | STEAM_USERNAME          | Y        |               | Steam user used to login to steamcmd, must own Arma3.
 | STEAM_VALIDATE          | N        | 1             | Validates files after Steam download
 | WORKSHOP_MODS           | N        |               | URL or file path to load mods
-| CHECK_MODS              | Y        |               | Integer flag between [0,1] used to enable the checking of new mods in the modlist or validation of old ones. Putting it to 0 means faster startup.
+| CHECK_MODS              | Y        |               | Integer flag between [0,1] used to enable the checking of new mods in the modlist or validation of old ones. Putting it to 0 means faster startup but it won't download any mods and it won't validate existing ones.
 | DOWNLOAD_ATTEMPTS       |Y         |               | Integer value between [1,MAX_INT] that specifies how many times the steamcmd workshop mod download has to be attempted. With big mods, sometimes steamcmd times out skipping to the next download. With this in place it will do DOWNLOAD_ATTEMPTS iterations of download so that hopefully everything is downloaded after all the attempts. Suggested value is 2.
 
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Allows for caching steam, Arma3, and workshop mods install OR downloading any (o
 | STEAM_USERNAME          | Y        |               | Steam user used to login to steamcmd, must own Arma3.
 | STEAM_VALIDATE          | N        | 1             | Validates files after Steam download
 | WORKSHOP_MODS           | N        |               | URL or file path to load mods
+| CHECK_MODS              | Y        |               | Integer flag between [0,1] used to enable the checking of new mods in the modlist or validation of old ones. Putting it to 0 means faster startup.
+| DOWNLOAD_ATTEMPTS       |Y         |               | Integer value between [1,MAX_INT] that specifies how many times the steamcmd workshop mod download has to be attempted. With big mods, sometimes steamcmd times out skipping to the next download. With this in place it will do DOWNLOAD_ATTEMPTS iterations of download so that hopefully everything is downloaded after all the attempts. Suggested value is 2.
 
 
 ### Directories used


### PR DESCRIPTION
I've slightly modified the a3update.py to be more reliable. The problem is that steamcmd times out when downloading big mods.

So the main changes are that instead of launching steamcmd with the "+argument" I made it so that it launches using a .txt file. The txt file is generated by a3update.py it self and then when the workshop download has to be called, it launches steam with the specified script file. From what I've read online this system makes it more reliable.

2 more environment variables have been added:
- CHECK_MODS enables/disables the mods download and validation. If it's set to 0 it wont check for the preset.html and won't validate already downloaded mods. When CHECK_MODS is set to 0 it will still launch the server with all the previously downloaded mods.
- DOWNLOAD_ATTEMPTS specifies the amount steamcmd workshop download iterations. Basically, again, it's a workaround for the unreliable mess that steamcmd is. 